### PR TITLE
Fix build on Windows

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_github_glog_glog",
-    sha256 = "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c",
-    strip_prefix = "glog-0.4.0",
-    urls = ["https://github.com/google/glog/archive/v0.4.0.tar.gz"],
+    sha256 = "cbba86b5a63063999e0fc86de620a3ad22d6fd2aa5948bff4995dcd851074a0b",
+    strip_prefix = "glog-c8f8135a5720aee7de8328b42e4c43f8aa2e60aa",
+    urls = ["https://github.com/google/glog/archive/c8f8135a5720aee7de8328b42e4c43f8aa2e60aa.zip"],
 )
 
 # gflags

--- a/client.cc
+++ b/client.cc
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#define GLOG_NO_ABBREVIATED_SEVERITIES
+#include "glog/logging.h"
 #include "gflags/gflags.h"
 
 #include "include/grpc/grpc_security_constants.h"

--- a/crypto/openssl_init.cc
+++ b/crypto/openssl_init.cc
@@ -14,6 +14,7 @@
  */
 
 #include "crypto/openssl_init.h"
+#include "openssl/base.h"  // For OPENSSL_IS_BORINGSSL.
 
 #if !defined(OPENSSL_IS_BORINGSSL)
 #include <pthread.h>

--- a/generate_dummy_data.cc
+++ b/generate_dummy_data.cc
@@ -18,6 +18,7 @@
 
 #include "gflags/gflags.h"
 
+#define GLOG_NO_ABBREVIATED_SEVERITIES
 #include "glog/logging.h"
 #include "data_util.h"
 

--- a/server.cc
+++ b/server.cc
@@ -18,6 +18,9 @@
 #include <string>
 #include <thread>  // NOLINT
 
+
+#define GLOG_NO_ABBREVIATED_SEVERITIES
+#include "glog/logging.h"
 #include "gflags/gflags.h"
 
 #include "include/grpc/grpc_security_constants.h"


### PR DESCRIPTION
This updates glog to the latest git version, and consistently defines `GLOG_NO_ABBREVIATED_SEVERITIES` to make the library build on Windows.