### PR TITLE
lifts 4mb restriction of gRPC messages

### DIFF
--- a/client.cc
+++ b/client.cc
@@ -100,11 +100,15 @@ int ExecuteProtocol() {
           std::move(client_identifiers_and_associated_values.second),
           FLAGS_paillier_modulus_size);
 
+  grpc::ChannelArguments ch_args;
+  ch_args.SetMaxReceiveMessageSize(-1); // consider limiting max message size
+
   // Consider grpc::SslServerCredentials if not running locally.
   std::unique_ptr<PrivateJoinAndComputeRpc::Stub> stub =
-      PrivateJoinAndComputeRpc::NewStub(::grpc::CreateChannel(
-          FLAGS_port, ::grpc::experimental::LocalCredentials(
-                          grpc_local_connect_type::LOCAL_TCP)));
+      PrivateJoinAndComputeRpc::NewStub(::grpc::CreateCustomChannel(
+          FLAGS_port,
+          ::grpc::experimental::LocalCredentials(grpc_local_connect_type::LOCAL_TCP),
+          ch_args));
   InvokeServerHandleClientMessageSink invoke_server_handle_message_sink(
       std::move(stub));
 

--- a/server.cc
+++ b/server.cc
@@ -61,6 +61,7 @@ int RunServer() {
   builder.AddListeningPort(FLAGS_port,
                            ::grpc::experimental::LocalServerCredentials(
                                grpc_local_connect_type::LOCAL_TCP));
+  builder.SetMaxReceiveMessageSize(INT_MAX); // consider limiting max message size
   builder.RegisterService(&service);
   std::unique_ptr<::grpc::Server> grpc_server(builder.BuildAndStart());
 


### PR DESCRIPTION
Fixes issue #16.
This is ok for a POC, in real life scenario max message size should obviously be limited.