### PR TITLE
Partial export of internal changes.

### DIFF
--- a/private_join_and_compute/crypto/dodis_yampolskiy_prf/BUILD
+++ b/private_join_and_compute/crypto/dodis_yampolskiy_prf/BUILD
@@ -115,6 +115,7 @@ cc_library(
 
 cc_test(
     name = "bb_oblivious_signature_test",
+    timeout = "long",
     srcs = [
         "bb_oblivious_signature_test.cc",
     ],

--- a/private_join_and_compute/crypto/fixed_base_exp.cc
+++ b/private_join_and_compute/crypto/fixed_base_exp.cc
@@ -26,6 +26,7 @@
 
 #include "private_join_and_compute/crypto/fixed_base_exp.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/private_join_and_compute/crypto/simultaneous_fixed_bases_exp.cc
+++ b/private_join_and_compute/crypto/simultaneous_fixed_bases_exp.cc
@@ -16,10 +16,16 @@
 #include "private_join_and_compute/crypto/simultaneous_fixed_bases_exp.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
+#include <utility>
 #include <vector>
 
+#include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
+#include "private_join_and_compute/crypto/big_num.h"
 #include "private_join_and_compute/crypto/mont_mul.h"
+#include "private_join_and_compute/util/status.inc"
 
 namespace private_join_and_compute {
 

--- a/private_join_and_compute/crypto/simultaneous_fixed_bases_exp.h
+++ b/private_join_and_compute/crypto/simultaneous_fixed_bases_exp.h
@@ -30,11 +30,14 @@
 #ifndef PRIVATE_JOIN_AND_COMPUTE_CRYPTO_SIMULTANEOUS_FIXED_BASES_H_
 #define PRIVATE_JOIN_AND_COMPUTE_CRYPTO_SIMULTANEOUS_FIXED_BASES_H_
 
+#include <cstddef>
+#include <memory>
 #include <vector>
 
 #include "private_join_and_compute/crypto/big_num.h"
 #include "private_join_and_compute/crypto/ec_point.h"
 #include "private_join_and_compute/util/status.inc"
+
 namespace private_join_and_compute {
 
 // Template type definitions for elements of the multiplicative group mod n.

--- a/private_join_and_compute/crypto/simultaneous_fixed_bases_exp_test.cc
+++ b/private_join_and_compute/crypto/simultaneous_fixed_bases_exp_test.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/private_join_and_compute/py/ciphers/BUILD
+++ b/private_join_and_compute/py/ciphers/BUILD
@@ -15,8 +15,8 @@
 # Description:
 #   Contains libraries for openssl big num operations.
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pip_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/private_join_and_compute/py/crypto_util/BUILD
+++ b/private_join_and_compute/py/crypto_util/BUILD
@@ -15,8 +15,8 @@
 # Description:
 #   Contains libraries for openssl big num operations.
 
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pip_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/private_join_and_compute/util/status.inc
+++ b/private_join_and_compute/util/status.inc
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
+#include "absl/status/status.h"    // IWYU pragma: export
+#include "absl/status/statusor.h"  // IWYU pragma: export
 
 #include "private_join_and_compute/util/status_macros.h"
 


### PR DESCRIPTION
Fixes build failures observed when the code is built in AOSP with Protobuf 22.x.

Omitted changes related to Protobuf editions for now as they're not yet supported in AOSP.