### PR TITLE
Rename ASSIGN_OR_RETURN macro

### DIFF
--- a/private_join_and_compute/crypto/camenisch_shoup.cc
+++ b/private_join_and_compute/crypto/camenisch_shoup.cc
@@ -127,12 +127,12 @@ StatusOr<CamenischShoupCiphertext> CommonEncryptWithRand(
         "not share prime factors with n.");
   }
 
-  ASSIGN_OR_RETURN(BigNum u, g_fbe->ModExp(r));
+  PJC_ASSIGN_OR_RETURN(BigNum u, g_fbe->ModExp(r));
 
   std::vector<BigNum> es;
   es.reserve(ys_fbe.size());
   for (size_t i = 0; i < ys_fbe.size(); i++) {
-    ASSIGN_OR_RETURN(BigNum y_to_r, ys_fbe[i]->ModExp(r));
+    PJC_ASSIGN_OR_RETURN(BigNum y_to_r, ys_fbe[i]->ModExp(r));
     if (i < ms.size()) {
       BigNum one_plus_n_to_m =
           ComputeByBinomialExpansion(ctx, precomp, powers, ms[i]);
@@ -161,7 +161,7 @@ StatusOr<CamenischShoupCiphertextWithRand> CommonEncryptAndGetRand(
   }
 
   BigNum r = ctx->RelativelyPrimeRandomLessThan(n);
-  ASSIGN_OR_RETURN(CamenischShoupCiphertext ct,
+  PJC_ASSIGN_OR_RETURN(CamenischShoupCiphertext ct,
                    CommonEncryptWithRand(ctx, ms, r, n, n_to_s, precomp, powers,
                                          g_fbe, ys_fbe, modulus));
 
@@ -174,7 +174,7 @@ StatusOr<CamenischShoupCiphertext> CommonEncrypt(
     const std::vector<BigNum>& powers, const FixedBaseExp* g_fbe,
     const std::vector<std::unique_ptr<FixedBaseExp>>& ys_fbe,
     const BigNum& modulus) {
-  ASSIGN_OR_RETURN(auto encryption_and_randomness,
+  PJC_ASSIGN_OR_RETURN(auto encryption_and_randomness,
                    CommonEncryptAndGetRand(ctx, ms, n, n_to_s, precomp, powers,
                                            g_fbe, ys_fbe, modulus));
   return {std::move(encryption_and_randomness.ct)};
@@ -359,7 +359,7 @@ PublicCamenischShoup::PublicCamenischShoup(Context* ctx, const BigNum& n,
 
 StatusOr<std::unique_ptr<PublicCamenischShoup>> PublicCamenischShoup::FromProto(
     Context* ctx, const proto::CamenischShoupPublicKey& public_key_proto) {
-  ASSIGN_OR_RETURN(CamenischShoupPublicKey public_key,
+  PJC_ASSIGN_OR_RETURN(CamenischShoupPublicKey public_key,
                    ParseCamenischShoupPublicKeyProto(ctx, public_key_proto));
   return std::make_unique<PublicCamenischShoup>(ctx, public_key.n, public_key.s,
                                                 public_key.g, public_key.ys);
@@ -442,9 +442,9 @@ StatusOr<std::unique_ptr<PrivateCamenischShoup>>
 PrivateCamenischShoup::FromProto(
     Context* ctx, const proto::CamenischShoupPublicKey& public_key_proto,
     const proto::CamenischShoupPrivateKey& private_key_proto) {
-  ASSIGN_OR_RETURN(CamenischShoupPublicKey public_key,
+  PJC_ASSIGN_OR_RETURN(CamenischShoupPublicKey public_key,
                    ParseCamenischShoupPublicKeyProto(ctx, public_key_proto));
-  ASSIGN_OR_RETURN(CamenischShoupPrivateKey private_key,
+  PJC_ASSIGN_OR_RETURN(CamenischShoupPrivateKey private_key,
                    ParseCamenischShoupPrivateKeyProto(ctx, private_key_proto));
   return std::make_unique<PrivateCamenischShoup>(ctx, public_key.n,
                                                  public_key.s, public_key.g,
@@ -486,7 +486,7 @@ StatusOr<std::vector<BigNum>> PrivateCamenischShoup::Decrypt(
   ms.reserve(vector_encryption_length_);
 
   for (uint64_t i = 0; i < vector_encryption_length_; i++) {
-    ASSIGN_OR_RETURN(BigNum s,
+    PJC_ASSIGN_OR_RETURN(BigNum s,
                      ct.u.ModExp(xs_[i], modulus_).ModInverse(modulus_));
     BigNum denoised = ct.es[i].ModMul(s, modulus_);
 

--- a/private_join_and_compute/crypto/commutative_elgamal.cc
+++ b/private_join_and_compute/crypto/commutative_elgamal.cc
@@ -48,8 +48,8 @@ CommutativeElGamal::CommutativeElGamal(
 StatusOr<std::unique_ptr<CommutativeElGamal>>
 CommutativeElGamal::CreateWithNewKeyPair(int curve_id) {
   std::unique_ptr<Context> context(new Context);
-  ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
-  ASSIGN_OR_RETURN(auto key_pair, elgamal::GenerateKeyPair(group));
+  PJC_ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
+  PJC_ASSIGN_OR_RETURN(auto key_pair, elgamal::GenerateKeyPair(group));
   std::unique_ptr<CommutativeElGamal> result(new CommutativeElGamal(
       std::move(context), std::move(group), std::move(key_pair.first),
       std::move(key_pair.second)));
@@ -60,10 +60,10 @@ StatusOr<std::unique_ptr<CommutativeElGamal>>
 CommutativeElGamal::CreateFromPublicKey(
     int curve_id, const std::pair<std::string, std::string>& public_key_bytes) {
   std::unique_ptr<Context> context(new Context);
-  ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
+  PJC_ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
 
-  ASSIGN_OR_RETURN(ECPoint g, group.CreateECPoint(public_key_bytes.first));
-  ASSIGN_OR_RETURN(ECPoint y, group.CreateECPoint(public_key_bytes.second));
+  PJC_ASSIGN_OR_RETURN(ECPoint g, group.CreateECPoint(public_key_bytes.first));
+  PJC_ASSIGN_OR_RETURN(ECPoint y, group.CreateECPoint(public_key_bytes.second));
 
   std::unique_ptr<elgamal::PublicKey> public_key(
       new elgamal::PublicKey({std::move(g), std::move(y)}));
@@ -77,14 +77,14 @@ CommutativeElGamal::CreateFromPublicAndPrivateKeys(
     int curve_id, const std::pair<std::string, std::string>& public_key_bytes,
     absl::string_view private_key_bytes) {
   std::unique_ptr<Context> context(new Context);
-  ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
+  PJC_ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
 
-  ASSIGN_OR_RETURN(ECPoint g, group.CreateECPoint(public_key_bytes.first));
-  ASSIGN_OR_RETURN(ECPoint y, group.CreateECPoint(public_key_bytes.second));
+  PJC_ASSIGN_OR_RETURN(ECPoint g, group.CreateECPoint(public_key_bytes.first));
+  PJC_ASSIGN_OR_RETURN(ECPoint y, group.CreateECPoint(public_key_bytes.second));
 
   BigNum x = context->CreateBigNum(private_key_bytes);
 
-  ASSIGN_OR_RETURN(ECPoint expected_y, g.Mul(x));
+  PJC_ASSIGN_OR_RETURN(ECPoint expected_y, g.Mul(x));
 
   if (y != expected_y) {
     return InvalidArgumentError(
@@ -104,26 +104,26 @@ CommutativeElGamal::CreateFromPublicAndPrivateKeys(
 
 StatusOr<std::pair<std::string, std::string>> CommutativeElGamal::Encrypt(
     absl::string_view plaintext) const {
-  ASSIGN_OR_RETURN(ECPoint plaintext_point, group_.CreateECPoint(plaintext));
+  PJC_ASSIGN_OR_RETURN(ECPoint plaintext_point, group_.CreateECPoint(plaintext));
 
-  ASSIGN_OR_RETURN(elgamal::Ciphertext ciphertext,
+  PJC_ASSIGN_OR_RETURN(elgamal::Ciphertext ciphertext,
                    encrypter_->Encrypt(plaintext_point));
 
-  ASSIGN_OR_RETURN(std::string u_string, ciphertext.u.ToBytesCompressed());
-  ASSIGN_OR_RETURN(std::string e_string, ciphertext.e.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(std::string u_string, ciphertext.u.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(std::string e_string, ciphertext.e.ToBytesCompressed());
 
   return {std::make_pair(std::move(u_string), std::move(e_string))};
 }
 
 StatusOr<std::pair<std::string, std::string>>
 CommutativeElGamal::EncryptIdentityElement() const {
-  ASSIGN_OR_RETURN(ECPoint plaintext_point, group_.GetPointAtInfinity());
+  PJC_ASSIGN_OR_RETURN(ECPoint plaintext_point, group_.GetPointAtInfinity());
 
-  ASSIGN_OR_RETURN(elgamal::Ciphertext ciphertext,
+  PJC_ASSIGN_OR_RETURN(elgamal::Ciphertext ciphertext,
                    encrypter_->Encrypt(plaintext_point));
 
-  ASSIGN_OR_RETURN(std::string u_string, ciphertext.u.ToBytesCompressed());
-  ASSIGN_OR_RETURN(std::string e_string, ciphertext.e.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(std::string u_string, ciphertext.u.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(std::string e_string, ciphertext.e.ToBytesCompressed());
 
   return {std::make_pair(std::move(u_string), std::move(e_string))};
 }
@@ -135,15 +135,15 @@ StatusOr<std::string> CommutativeElGamal::Decrypt(
         "CommutativeElGamal::Decrypt: cannot decrypt without the private key.");
   }
 
-  ASSIGN_OR_RETURN(ECPoint u_point, group_.CreateECPoint(ciphertext.first));
-  ASSIGN_OR_RETURN(ECPoint e_point, group_.CreateECPoint(ciphertext.second));
+  PJC_ASSIGN_OR_RETURN(ECPoint u_point, group_.CreateECPoint(ciphertext.first));
+  PJC_ASSIGN_OR_RETURN(ECPoint e_point, group_.CreateECPoint(ciphertext.second));
   elgamal::Ciphertext decoded_ciphertext(
       {std::move(u_point), std::move(e_point)});
 
-  ASSIGN_OR_RETURN(ECPoint plaintext_point,
+  PJC_ASSIGN_OR_RETURN(ECPoint plaintext_point,
                    decrypter_->Decrypt(decoded_ciphertext));
 
-  ASSIGN_OR_RETURN(std::string plaintext, plaintext_point.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(std::string plaintext, plaintext_point.ToBytesCompressed());
 
   return {std::move(plaintext)};
 }
@@ -151,8 +151,8 @@ StatusOr<std::string> CommutativeElGamal::Decrypt(
 StatusOr<std::pair<std::string, std::string>>
 CommutativeElGamal::GetPublicKeyBytes() const {
   const elgamal::PublicKey* public_key = encrypter_->getPublicKey();
-  ASSIGN_OR_RETURN(std::string g_string, public_key->g.ToBytesCompressed());
-  ASSIGN_OR_RETURN(std::string y_string, public_key->y.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(std::string g_string, public_key->g.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(std::string y_string, public_key->y.ToBytesCompressed());
 
   return {std::make_pair(std::move(g_string), std::move(y_string))};
 }

--- a/private_join_and_compute/crypto/ec_point_util.cc
+++ b/private_join_and_compute/crypto/ec_point_util.cc
@@ -34,26 +34,26 @@ ECPointUtil::ECPointUtil(std::unique_ptr<Context> context, ECGroup group)
 
 StatusOr<std::unique_ptr<ECPointUtil>> ECPointUtil::Create(int curve_id) {
   std::unique_ptr<Context> context(new Context());
-  ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
+  PJC_ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, context.get()));
   return std::unique_ptr<ECPointUtil>(
       new ECPointUtil(std::move(context), std::move(group)));
 }
 
 StatusOr<std::string> ECPointUtil::GetRandomCurvePoint() {
-  ASSIGN_OR_RETURN(ECPoint point, group_.GetRandomGenerator());
+  PJC_ASSIGN_OR_RETURN(ECPoint point, group_.GetRandomGenerator());
   return point.ToBytesCompressed();
 }
 
 StatusOr<std::string> ECPointUtil::HashToCurve(
     absl::string_view input, ECCommutativeCipher::HashType hash_type) {
   if (hash_type == ECCommutativeCipher::HashType::SHA512) {
-    ASSIGN_OR_RETURN(ECPoint point,
+    PJC_ASSIGN_OR_RETURN(ECPoint point,
                      group_.GetPointByHashingToCurveSha512(input));
     return point.ToBytesCompressed();
   }
 
   if (hash_type == ECCommutativeCipher::HashType::SHA256) {
-    ASSIGN_OR_RETURN(ECPoint point,
+    PJC_ASSIGN_OR_RETURN(ECPoint point,
                      group_.GetPointByHashingToCurveSha256(input));
     return point.ToBytesCompressed();
   }

--- a/private_join_and_compute/crypto/paillier.cc
+++ b/private_join_and_compute/crypto/paillier.cc
@@ -260,7 +260,7 @@ class PrimeCrypto {
   // the value.)
   StatusOr<BigNum> EncryptWithRand(const BigNum& m, const BigNum& r) const {
     BigNum c_p = ComputeByBinomialExpansion(ctx_, precomp_, powers_, m);
-    ASSIGN_OR_RETURN(BigNum g_to_r, fbe_->ModExp(r));
+    PJC_ASSIGN_OR_RETURN(BigNum g_to_r, fbe_->ModExp(r));
     return c_p.ModMul(g_to_r, powers_[s_ + 1]);
   }
 
@@ -341,8 +341,8 @@ class PrimeCryptoWithRand {
   // random used.
   StatusOr<PaillierEncAndRand> EncryptAndGetRand(const BigNum& m) const {
     BigNum r = ctx_->GenerateRandBetween(ctx_->One(), prime_crypto_->p_);
-    ASSIGN_OR_RETURN(BigNum ct, EncryptWithRand(m, r));
-    ASSIGN_OR_RETURN(BigNum exp_for_report_to_r, exp_for_report_->ModExp(r));
+    PJC_ASSIGN_OR_RETURN(BigNum ct, EncryptWithRand(m, r));
+    PJC_ASSIGN_OR_RETURN(BigNum exp_for_report_to_r, exp_for_report_->ModExp(r));
     return {{std::move(ct), std::move(exp_for_report_to_r)}};
   }
 
@@ -411,7 +411,7 @@ StatusOr<BigNum> PublicPaillier::EncryptUsingGeneratorAndRand(
         "PublicPaillier: The given random is not less than or equal to n.");
   }
   BigNum c = ComputeByBinomialExpansion(ctx_, precomp_, n_powers_, m);
-  ASSIGN_OR_RETURN(BigNum g_n_to_r, g_n_fbe_->ModExp(r));
+  PJC_ASSIGN_OR_RETURN(BigNum g_n_to_r, g_n_fbe_->ModExp(r));
   return c.ModMul(g_n_to_r, modulus_);
 }
 
@@ -428,7 +428,7 @@ StatusOr<BigNum> PublicPaillier::EncryptWithRand(const BigNum& m,
 StatusOr<PaillierEncAndRand> PublicPaillier::EncryptAndGetRand(
     const BigNum& m) const {
   BigNum r = ctx_->RelativelyPrimeRandomLessThan(n_);
-  ASSIGN_OR_RETURN(BigNum c, EncryptWithRand(m, r));
+  PJC_ASSIGN_OR_RETURN(BigNum c, EncryptWithRand(m, r));
   return {{std::move(c), std::move(r)}};
 }
 
@@ -461,8 +461,8 @@ StatusOr<BigNum> PrivatePaillier::Encrypt(const BigNum& m) const {
     return InvalidArgumentError(
         "PrivatePaillier::Encrypt() - Message not smaller than n^s.");
   }
-  ASSIGN_OR_RETURN(BigNum p_ct, p_crypto_->Encrypt(m));
-  ASSIGN_OR_RETURN(BigNum q_ct, q_crypto_->Encrypt(m));
+  PJC_ASSIGN_OR_RETURN(BigNum p_ct, p_crypto_->Encrypt(m));
+  PJC_ASSIGN_OR_RETURN(BigNum q_ct, q_crypto_->Encrypt(m));
   return two_mod_crt_encrypt_->Compute(p_ct, q_ct);
 }
 
@@ -511,9 +511,9 @@ StatusOr<PaillierEncAndRand> PrivatePaillierWithRand::EncryptAndGetRand(
         "PrivatePaillier::Encrypt() - Message not smaller than n^s.");
   }
 
-  ASSIGN_OR_RETURN(const PaillierEncAndRand enc_p,
+  PJC_ASSIGN_OR_RETURN(const PaillierEncAndRand enc_p,
                    p_crypto_->EncryptAndGetRand(m));
-  ASSIGN_OR_RETURN(const PaillierEncAndRand enc_q,
+  PJC_ASSIGN_OR_RETURN(const PaillierEncAndRand enc_q,
                    q_crypto_->EncryptAndGetRand(m));
 
   BigNum c = private_paillier_->two_mod_crt_encrypt_->Compute(enc_p.ciphertext,

--- a/private_join_and_compute/crypto/pedersen_over_zn.cc
+++ b/private_join_and_compute/crypto/pedersen_over_zn.cc
@@ -65,7 +65,7 @@ StatusOr<std::unique_ptr<PedersenOverZn>> PedersenOverZn::Create(
 StatusOr<std::unique_ptr<PedersenOverZn>> PedersenOverZn::FromProto(
     Context* ctx, const proto::PedersenParameters& parameters_proto,
     size_t num_simultaneous_exponentiations) {
-  ASSIGN_OR_RETURN(PedersenOverZn::Parameters parameters,
+  PJC_ASSIGN_OR_RETURN(PedersenOverZn::Parameters parameters,
                    PedersenOverZn::ParseParametersProto(ctx, parameters_proto));
   return PedersenOverZn::Create(ctx, std::move(parameters.gs), parameters.h,
                                 parameters.n, num_simultaneous_exponentiations);
@@ -76,7 +76,7 @@ PedersenOverZn::~PedersenOverZn() = default;
 StatusOr<PedersenOverZn::CommitmentAndOpening> PedersenOverZn::Commit(
     const std::vector<BigNum>& messages) const {
   BigNum r = ctx_->GenerateRandLessThan(n_);
-  ASSIGN_OR_RETURN(auto commitment,
+  PJC_ASSIGN_OR_RETURN(auto commitment,
                    PedersenOverZn::CommitWithRand(messages, r));
   return {{std::move(commitment), std::move(r)}};
 }
@@ -106,7 +106,7 @@ StatusOr<PedersenOverZn::Commitment> PedersenOverZn::CommitWithRand(
   }
   // Push back the exponent for h_.
   exponents.push_back(rand);
-  ASSIGN_OR_RETURN(BigNum product,
+  PJC_ASSIGN_OR_RETURN(BigNum product,
                    simultaneous_fixed_bases_exp_->SimultaneousExp(exponents));
 
   return std::move(product);
@@ -150,7 +150,7 @@ StatusOr<bool> PedersenOverZn::Verify(
   }
   // Push back the exponent for h_.
   exponents.push_back(opening);
-  ASSIGN_OR_RETURN(BigNum product,
+  PJC_ASSIGN_OR_RETURN(BigNum product,
                    simultaneous_fixed_bases_exp_->SimultaneousExp(exponents));
 
   return commitment == product;

--- a/private_join_and_compute/crypto/shanks_discrete_log.cc
+++ b/private_join_and_compute/crypto/shanks_discrete_log.cc
@@ -51,11 +51,11 @@ absl::StatusOr<std::map<std::string, int>> ShanksDiscreteLog::PrecomputeTable(
     const private_join_and_compute::ECGroup* group,
     const private_join_and_compute::ECPoint* generator, int precompute_bits) {
   std::map<std::string, int> table;
-  ASSIGN_OR_RETURN(auto point, group->GetPointAtInfinity());
+  PJC_ASSIGN_OR_RETURN(auto point, group->GetPointAtInfinity());
   // Cannot encode point at infinity to bytes.
   for (int i = 1; i < (1 << precompute_bits); ++i) {
-    ASSIGN_OR_RETURN(point, generator->Add(point));
-    ASSIGN_OR_RETURN(auto bytes, point.ToBytesCompressed());
+    PJC_ASSIGN_OR_RETURN(point, generator->Add(point));
+    PJC_ASSIGN_OR_RETURN(auto bytes, point.ToBytesCompressed());
     table.insert(std::pair<std::string, int>(bytes, i));
   }
   return table;
@@ -75,10 +75,10 @@ absl::StatusOr<std::unique_ptr<ShanksDiscreteLog>> ShanksDiscreteLog::Create(
         absl::StrCat("Maximum number of message bits should be at most ",
                      kMaxMessageSize, "."));
   }
-  ASSIGN_OR_RETURN(auto generator_clone, generator->Clone());
+  PJC_ASSIGN_OR_RETURN(auto generator_clone, generator->Clone());
   auto generator_ptr = std::make_unique<private_join_and_compute::ECPoint>(
       std::move(generator_clone));
-  ASSIGN_OR_RETURN(auto table,
+  PJC_ASSIGN_OR_RETURN(auto table,
                    PrecomputeTable(group, generator, precompute_bits));
   return absl::WrapUnique<ShanksDiscreteLog>(new ShanksDiscreteLog(
       ctx, group, std::move(generator_ptr), max_message_bits, precompute_bits,
@@ -87,10 +87,10 @@ absl::StatusOr<std::unique_ptr<ShanksDiscreteLog>> ShanksDiscreteLog::Create(
 
 absl::StatusOr<int64_t> ShanksDiscreteLog::GetDiscreteLog(
     const private_join_and_compute::ECPoint& point) {
-  ASSIGN_OR_RETURN(auto inverse, generator_->Inverse());
-  ASSIGN_OR_RETURN(auto baby_step,
+  PJC_ASSIGN_OR_RETURN(auto inverse, generator_->Inverse());
+  PJC_ASSIGN_OR_RETURN(auto baby_step,
                    inverse.Mul(ctx_->CreateBigNum(1 << precompute_bits_)));
-  ASSIGN_OR_RETURN(auto current_state, point.Clone());
+  PJC_ASSIGN_OR_RETURN(auto current_state, point.Clone());
   // Create guarantees that max_message_bits_ >= precompute_bits_.
   for (int i = 0; i < (1 << (max_message_bits_ - precompute_bits_)); ++i) {
     // Infinity cannot be encoded as bytes, so we explcitly check for infinity
@@ -100,7 +100,7 @@ absl::StatusOr<int64_t> ShanksDiscreteLog::GetDiscreteLog(
       shift <<= precompute_bits_;
       return shift * i;
     }
-    ASSIGN_OR_RETURN(auto bytes, current_state.ToBytesCompressed());
+    PJC_ASSIGN_OR_RETURN(auto bytes, current_state.ToBytesCompressed());
     auto iter = precomputed_table_.find(bytes);
     if (iter != precomputed_table_.end()) {
       int64_t shift = 1;
@@ -108,7 +108,7 @@ absl::StatusOr<int64_t> ShanksDiscreteLog::GetDiscreteLog(
       shift *= i;
       return shift + iter->second;
     }
-    ASSIGN_OR_RETURN(current_state, current_state.Add(baby_step));
+    PJC_ASSIGN_OR_RETURN(current_state, current_state.Add(baby_step));
   }
   return absl::InvalidArgumentError(
       "Could not find discrete log. Exponent larger than specified max size.");

--- a/private_join_and_compute/crypto/simultaneous_fixed_bases_exp.cc
+++ b/private_join_and_compute/crypto/simultaneous_fixed_bases_exp.cc
@@ -107,10 +107,10 @@ SimultaneousFixedBasesExp<Element, Context>::Create(
         ", can be at most the number of bases", bases.size(), "."));
   }
   size_t num_batches = (bases.size() + num_simultaneous - 1) / num_simultaneous;
-  ASSIGN_OR_RETURN(auto zero_clone, internal::Clone(zero));
+  PJC_ASSIGN_OR_RETURN(auto zero_clone, internal::Clone(zero));
   std::unique_ptr<Element> zero_ptr =
       std::make_unique<Element>(std::move(zero_clone));
-  ASSIGN_OR_RETURN(std::vector<std::vector<std::unique_ptr<Element>>> table,
+  PJC_ASSIGN_OR_RETURN(std::vector<std::vector<std::unique_ptr<Element>>> table,
                    SimultaneousFixedBasesExp::Precompute(
                        bases, zero, *context, num_simultaneous, num_batches));
   return absl::WrapUnique<SimultaneousFixedBasesExp>(
@@ -127,7 +127,7 @@ SimultaneousFixedBasesExp<Element, Context>::Precompute(
   std::vector<std::vector<std::unique_ptr<Element>>> table;
   for (size_t i = 0; i < num_batches; ++i) {
     table.push_back({});
-    ASSIGN_OR_RETURN(Element zero_clone, internal::Clone(zero));
+    PJC_ASSIGN_OR_RETURN(Element zero_clone, internal::Clone(zero));
     table[i].push_back(std::make_unique<Element>(std::move(zero_clone)));
     const size_t start = i * num_simultaneous;
     const size_t num_items_in_batch =
@@ -141,11 +141,11 @@ SimultaneousFixedBasesExp<Element, Context>::Precompute(
       }
       size_t prev = j - (1 << highest_one_bit);
       if (prev == 0) {
-        ASSIGN_OR_RETURN(Element clone,
+        PJC_ASSIGN_OR_RETURN(Element clone,
                          internal::Clone(bases[start + highest_one_bit]));
         table[i].push_back(std::make_unique<Element>(std::move(clone)));
       } else {
-        ASSIGN_OR_RETURN(
+        PJC_ASSIGN_OR_RETURN(
             Element add,
             internal::Mul(*(table[i][prev]), bases[start + highest_one_bit],
                           context));
@@ -170,10 +170,10 @@ StatusOr<Element> SimultaneousFixedBasesExp<Element, Context>::SimultaneousExp(
       max_bit_length = exponent.BitLength();
     }
   }
-  ASSIGN_OR_RETURN(Element result, internal::Clone(*zero_));
+  PJC_ASSIGN_OR_RETURN(Element result, internal::Clone(*zero_));
   for (int i = max_bit_length - 1; i >= 0; --i) {
     if (!internal::IsZero(result)) {
-      ASSIGN_OR_RETURN(result, internal::Mul(result, result, *context_));
+      PJC_ASSIGN_OR_RETURN(result, internal::Mul(result, result, *context_));
     }
     for (size_t j = 0; j < num_batches_; ++j) {
       size_t precompute_idx = 0;
@@ -188,7 +188,7 @@ StatusOr<Element> SimultaneousFixedBasesExp<Element, Context>::SimultaneousExp(
         }
       }
       if (precompute_idx) {
-        ASSIGN_OR_RETURN(
+        PJC_ASSIGN_OR_RETURN(
             result,
             internal::Mul(result, *(precomputed_table_[j][precompute_idx]),
                           *context_));

--- a/private_join_and_compute/util/ec_key_util.cc
+++ b/private_join_and_compute/util/ec_key_util.cc
@@ -24,7 +24,7 @@ namespace private_join_and_compute::ec_key_util {
 
 Status GenerateEcKey(int curve_id, absl::string_view ec_key_filename) {
   Context context;
-  ASSIGN_OR_RETURN(ECGroup ec_group, ECGroup::Create(curve_id, &context));
+  PJC_ASSIGN_OR_RETURN(ECGroup ec_group, ECGroup::Create(curve_id, &context));
   BigNum key = ec_group.GeneratePrivateKey();
   EcKeyProto key_proto;
   key_proto.set_curve_id(curve_id);

--- a/private_join_and_compute/util/elgamal_key_util.cc
+++ b/private_join_and_compute/util/elgamal_key_util.cc
@@ -37,13 +37,13 @@ using private_join_and_compute::ProtoUtils;
 Status GenerateElGamalKeyPair(int curve_id, absl::string_view pub_key_filename,
                               absl::string_view prv_key_filename) {
   Context context;
-  ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, &context));
-  ASSIGN_OR_RETURN(auto key_pair,
+  PJC_ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, &context));
+  PJC_ASSIGN_OR_RETURN(auto key_pair,
                    private_join_and_compute::elgamal::GenerateKeyPair(group));
-  ASSIGN_OR_RETURN(
+  PJC_ASSIGN_OR_RETURN(
       auto public_key_proto,
       elgamal_proto_util::SerializePublicKey(*key_pair.first.get()));
-  ASSIGN_OR_RETURN(
+  PJC_ASSIGN_OR_RETURN(
       auto private_key_proto,
       elgamal_proto_util::SerializePrivateKey(*key_pair.second.get()));
   RETURN_IF_ERROR(
@@ -62,20 +62,20 @@ Status ComputeJointElGamalPublicKey(
         "provided");
   }
   Context context;
-  ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, &context));
+  PJC_ASSIGN_OR_RETURN(ECGroup group, ECGroup::Create(curve_id, &context));
   std::vector<std::unique_ptr<elgamal::PublicKey>> shares;
   for (const auto& share_file : shares_filenames) {
-    ASSIGN_OR_RETURN(
+    PJC_ASSIGN_OR_RETURN(
         auto key_share_proto,
         ProtoUtils::ReadProtoFromFile<ElGamalPublicKey>(share_file));
-    ASSIGN_OR_RETURN(auto key_share, elgamal_proto_util::DeserializePublicKey(
+    PJC_ASSIGN_OR_RETURN(auto key_share, elgamal_proto_util::DeserializePublicKey(
                                          &group, key_share_proto));
     shares.push_back(std::move(key_share));
   }
-  ASSIGN_OR_RETURN(
+  PJC_ASSIGN_OR_RETURN(
       auto joint_key,
       private_join_and_compute::elgamal::GeneratePublicKeyFromShares(shares));
-  ASSIGN_OR_RETURN(auto joint_key_proto,
+  PJC_ASSIGN_OR_RETURN(auto joint_key_proto,
                    elgamal_proto_util::SerializePublicKey(*joint_key.get()));
   RETURN_IF_ERROR(
       ProtoUtils::WriteProtoToFile(joint_key_proto, join_pub_key_key_filename));

--- a/private_join_and_compute/util/elgamal_proto_util.cc
+++ b/private_join_and_compute/util/elgamal_proto_util.cc
@@ -25,9 +25,9 @@ namespace private_join_and_compute::elgamal_proto_util {
 StatusOr<ElGamalPublicKey> SerializePublicKey(
     const elgamal::PublicKey& public_key_struct) {
   ElGamalPublicKey public_key_proto;
-  ASSIGN_OR_RETURN(auto serialized_g, public_key_struct.g.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(auto serialized_g, public_key_struct.g.ToBytesCompressed());
   public_key_proto.set_g(serialized_g);
-  ASSIGN_OR_RETURN(auto serialized_y, public_key_struct.y.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(auto serialized_y, public_key_struct.y.ToBytesCompressed());
   public_key_proto.set_y(serialized_y);
   return public_key_proto;
 }
@@ -35,9 +35,9 @@ StatusOr<ElGamalPublicKey> SerializePublicKey(
 StatusOr<ElGamalCiphertext> SerializeCiphertext(
     const elgamal::Ciphertext& ciphertext_struct) {
   ElGamalCiphertext ciphertext_proto;
-  ASSIGN_OR_RETURN(auto serialized_u, ciphertext_struct.u.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(auto serialized_u, ciphertext_struct.u.ToBytesCompressed());
   ciphertext_proto.set_u(serialized_u);
-  ASSIGN_OR_RETURN(auto serialized_e, ciphertext_struct.e.ToBytesCompressed());
+  PJC_ASSIGN_OR_RETURN(auto serialized_e, ciphertext_struct.e.ToBytesCompressed());
   ciphertext_proto.set_e(serialized_e);
   return ciphertext_proto;
 }
@@ -51,9 +51,9 @@ StatusOr<ElGamalSecretKey> SerializePrivateKey(
 
 StatusOr<std::unique_ptr<elgamal::PublicKey>> DeserializePublicKey(
     const ECGroup* ec_group, const ElGamalPublicKey& public_key_proto) {
-  ASSIGN_OR_RETURN(ECPoint public_key_struct_g,
+  PJC_ASSIGN_OR_RETURN(ECPoint public_key_struct_g,
                    ec_group->CreateECPoint(public_key_proto.g()));
-  ASSIGN_OR_RETURN(ECPoint public_key_struct_y,
+  PJC_ASSIGN_OR_RETURN(ECPoint public_key_struct_y,
                    ec_group->CreateECPoint(public_key_proto.y()));
   return absl::WrapUnique(new elgamal::PublicKey(
       {std::move(public_key_struct_g), std::move(public_key_struct_y)}));
@@ -67,9 +67,9 @@ StatusOr<std::unique_ptr<elgamal::PrivateKey>> DeserializePrivateKey(
 
 StatusOr<elgamal::Ciphertext> DeserializeCiphertext(
     const ECGroup* ec_group, const ElGamalCiphertext& ciphertext_proto) {
-  ASSIGN_OR_RETURN(ECPoint ciphertext_struct_u,
+  PJC_ASSIGN_OR_RETURN(ECPoint ciphertext_struct_u,
                    ec_group->CreateECPoint(ciphertext_proto.u()));
-  ASSIGN_OR_RETURN(ECPoint ciphertext_struct_e,
+  PJC_ASSIGN_OR_RETURN(ECPoint ciphertext_struct_e,
                    ec_group->CreateECPoint(ciphertext_proto.e()));
   return elgamal::Ciphertext{std::move(ciphertext_struct_u),
                              std::move(ciphertext_struct_e)};

--- a/private_join_and_compute/util/proto_util.h
+++ b/private_join_and_compute/util/proto_util.h
@@ -82,11 +82,11 @@ inline StatusOr<std::vector<ProtoType>> ProtoUtils::ReadProtosFromFile(
   std::unique_ptr<RecordReader> reader(RecordReader::GetRecordReader());
   RETURN_IF_ERROR(reader->Open(filename));
   std::string raw_record;
-  ASSIGN_OR_RETURN(bool has_more, reader->HasMore());
+  PJC_ASSIGN_OR_RETURN(bool has_more, reader->HasMore());
   while (has_more) {
     RETURN_IF_ERROR(reader->Read(&raw_record));
     result.push_back(ProtoUtils::FromString<ProtoType>(raw_record));
-    ASSIGN_OR_RETURN(has_more, reader->HasMore());
+    PJC_ASSIGN_OR_RETURN(has_more, reader->HasMore());
   }
   RETURN_IF_ERROR(reader->Close());
   return std::move(result);

--- a/private_join_and_compute/util/recordio.cc
+++ b/private_join_and_compute/util/recordio.cc
@@ -49,7 +49,7 @@ StatusOr<uint32_t> ExtractVarint32(File* file) {
   std::string bytes_read = "";
 
   size_t current_byte = 0;
-  ASSIGN_OR_RETURN(auto has_more, file->HasMore());
+  PJC_ASSIGN_OR_RETURN(auto has_more, file->HasMore());
   while (current_byte < kMaxVarint32Size && has_more) {
     auto maybe_last_byte = file->Read(1);
     if (!maybe_last_byte.ok()) {
@@ -69,7 +69,7 @@ StatusOr<uint32_t> ExtractVarint32(File* file) {
           "number "
           "of bytes.");
     }
-    ASSIGN_OR_RETURN(has_more, file->HasMore());
+    PJC_ASSIGN_OR_RETURN(has_more, file->HasMore());
   }
 
   google::protobuf::io::ArrayInputStream arrayInputStream(bytes_read.data(),

--- a/private_join_and_compute/util/status_macros.h
+++ b/private_join_and_compute/util/status_macros.h
@@ -23,9 +23,9 @@
 // Helper macro that checks if the right hand side (rexpression) evaluates to a
 // StatusOr with Status OK, and if so assigns the value to the value on the left
 // hand side (lhs), otherwise returns the error status. Example:
-//   ASSIGN_OR_RETURN(lhs, rexpression);
-#ifndef ASSIGN_OR_RETURN
-#define ASSIGN_OR_RETURN(lhs, rexpr)                                       \
+//   PJC_ASSIGN_OR_RETURN(lhs, rexpression);
+#ifndef PJC_ASSIGN_OR_RETURN
+#define PJC_ASSIGN_OR_RETURN(lhs, rexpr)                                       \
   PRIVATE_JOIN_AND_COMPUTE_ASSIGN_OR_RETURN_IMPL_(                         \
       PRIVATE_JOIN_AND_COMPUTE_STATUS_MACROS_IMPL_CONCAT_(status_or_value, \
                                                           __LINE__),       \
@@ -38,7 +38,7 @@
     return std::move(statusor).status();                                      \
   }                                                                           \
   lhs = *std::move(statusor)
-#endif  // ASSIGN_OR_RETURN
+#endif  // PJC_ASSIGN_OR_RETURN
 
 // Helper macro that checks if the given expression evaluates to a
 // Status with Status OK. If not,  returns the error status. Example:


### PR DESCRIPTION
Rename `ASSIGN_OR_RETURN` macro to `PJC_ASSIGN_OR_RETURN`.

`ASSIGN_OR_RETURN` is widely used in other places as well. For two other definitions of `ASSING_OR_RETURN`, see

[protobuf `status_macros.h`](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/stubs/status_macros.h#L62)
[chromium `base/types/expected_macros.h`](https://source.chromium.org/chromium/chromium/src/+/main:base/types/expected_macros.h;drc=6d99adc6367638f22e4c2449932350a0bab91752;l=258)

This creates unexpected compilation errors in projects where private-join-and-compute is imported.

We are facing this problem in chromium code. Please see following discussions in chromium code reviews.

https://chromium-review.googlesource.com/c/chromium/src/+/6351478/comment/0007e149_b36ff744/ 
https://chromium-review.googlesource.com/c/chromium/src/+/6475724/comment/98f17bb5_918e2957/ 
https://chromium-review.googlesource.com/c/chromium/src/+/6475724/comment/98f17bb5_918e2957/
 https://chromium-review.googlesource.com/c/chromium/src/+/6475724/comments/d139f150_9ab5864b
